### PR TITLE
v2.3.7

### DIFF
--- a/WebExtension/data/JS/A7Init.js
+++ b/WebExtension/data/JS/A7Init.js
@@ -233,7 +233,7 @@ function init()
 
     // Ajoute la structure d'accueil des commentaires et de la barre utilisateur
     var listaParent = list.parentElement;
-
+    
     // Ajoute la barre utilisateur si non désactivée
     if (!A7Settings.disableUserBar)
     {

--- a/WebExtension/data/JS/InitFunctions.js
+++ b/WebExtension/data/JS/InitFunctions.js
@@ -86,8 +86,7 @@ function removeTitleIndicator()
     title.lastChild.remove();
     title.parentElement.parentElement.style.setProperty('visibility', 'visible');
 }
-
-
+ 
 /**
 * @fn linesChanged Met en cache les lignes et ajoute un événement sur les liens
 */
@@ -218,6 +217,7 @@ function linesChanged()
         // Cellules utiles
         var timeCell = currentLine.children[page.lock + 4];
         var textCell = currentLine.lastElementChild;
+        
         // on récupère la séquence
         var aLink = currentLine.children[0].querySelector('a');
         var seqNumber = (aLink ? aLink.innerHTML : "");
@@ -388,6 +388,36 @@ function linesChanged()
         var tables = lista.getElementsByTagName('table');
         tables[0].style.setProperty('visibility', 'visible');
         tables[1].style.setProperty('visibility', 'visible');
+    }
+
+    // on cherche à composer un lien unique qu'on pourra réutiliser plus tard sans devoir se rappeler à quelle page on est
+    let urlObject=new URL(window.location.href);
+    // si on n'a pas les paramètres dans l'URL, alors on va recharger la page avec les bons paramètres
+    if (!urlObject.searchParams.has("id")) {
+      // cherche les paramètres relatives à la page dans les scripts
+      let scripts = document.querySelectorAll('script');
+      for (let i=0; i<scripts.length; i++) {
+        let res = scripts[i].innerHTML.match(/translate_ajaxselect\.php\?(id=\d+&fversion=\d&langto=\d+&langfrom=\d+)/);
+        if (res) window.location.href = "?" + res[1];
+      }
+    }
+    // on modifie le lien de changement de page afin d'y ajouter le numéro de sequence
+    // exemple du code appelé sur ces liens: javascript:list('210');linesChanged();
+    // on change donc par une url avec tous les paramètres voulus
+    let linkPages = document.querySelectorAll("#lista > a");
+    let pageSourceUrl = window.location.href.replace(/&sequence=\d+/, "");
+    for (let i=0; i<linkPages.length; i++) {
+      let code = linkPages[i].getAttribute("href");
+      let sequence = (linkPages[i].innerText-1)*30 + 1;
+      linkPages[i].setAttribute("href", pageSourceUrl + "&sequence=" + sequence);
+      linkPages[i].onclick = function(event) {
+        event.preventDefault();
+        if (window.history.pushState) {
+          let newUrl = pageSourceUrl + "&sequence=" + sequence;
+          window.history.pushState({}, '', newUrl);
+        }
+        eval(code);
+      };
     }
 
     // Si la barre utilisateur est activée

--- a/WebExtension/data/JS/Settings.js
+++ b/WebExtension/data/JS/Settings.js
@@ -7,8 +7,8 @@
 // Déclaration de l'objet contenant tous les réglages
 var A7Settings = {
 
-    MAJOR_VERSION_INFO   : 'A7++ 2.3.6',
-    MINOR_VERSION_INFO   : '2.3.6 stable',
+    MAJOR_VERSION_INFO   : 'A7++ 2.3.7',
+    MINOR_VERSION_INFO   : '2.3.7 stable',
 
     // Longueur en caractères
     maxPerLineOneLineSETTING : 37,

--- a/WebExtension/data/launcher.js
+++ b/WebExtension/data/launcher.js
@@ -40,7 +40,6 @@ window.addEventListener("A7pp_player_request", function(data)
     }
 }, false);
 
-
 /*
  * Partie injection
  */
@@ -61,8 +60,8 @@ document.documentElement.appendChild(document.createElement('head'));
 document.head.appendChild(createScript('Settings.js'));
 document.head.appendChild(createScript('Localization.js'));
 
-document.head.appendChild(createScript('InitFunctions.js'));
 document.head.appendChild(createScript('UtilsFunctions.js'));
+document.head.appendChild(createScript('InitFunctions.js'));
 document.head.appendChild(createScript('HTMLCreation.js'));
 document.head.appendChild(createScript('Accessors.js'));
 

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
 
     "name": "A7++",
-    "version": "2.3.6",
+    "version": "2.3.7",
     "description": "__MSG_A7pp_extensionDescription__",
     "author": "Acc\u00eant, HitOrRun, Retrojex & Mmoi",
     "homepage_url": "https://github.com/A7plusplus/A7plusplus",


### PR DESCRIPTION
Cette pull request modifie le lien par défaut (https://www.addic7ed.com/translate.php) en un lien avec des paramètres. Grâce à ça, on a un accès rapide pour retourner à la traduction sur laquelle on travaillait.

Le lien comporte l'id de la série, le langage source et destination, ainsi qu'un numéro de séquence pour un accès direct : plus besoin de devoir se souvenir du numéro de page où on s'était arrêté, ni de devoir refaire le parcours jusqu'à la page de traduction !

Dès l'accès à la page `translate.php`, elle va se recharger pour utiliser les bons paramètres. Puis à chaque fois qu'on clique sur un numéro de page, le lien se met à jour sans tout recharger.

Exemple de lien, la page 10 : https://www.addic7ed.com/translate.php?id=173543&fversion=0&langto=8&langfrom=1&sequence=271